### PR TITLE
frr 기본 설정

### DIFF
--- a/Vagrantfile_frr
+++ b/Vagrantfile_frr
@@ -4,6 +4,7 @@ frr_script = <<-SCRIPT
   # Change the repository to Kakao
   sed -i 's/archive.ubuntu.com/mirror.kakao.com/g' /etc/apt/sources.list
   sed -i 's/security.ubuntu.com/mirror.kakao.com/g' /etc/apt/sources.list
+
   # Password Authentication for SSH
   sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
   sed -i 's/KbdInteractiveAuthentication no/KbdInteractiveAuthentication yes/g' /etc/ssh/sshd_config
@@ -13,19 +14,25 @@ frr_script = <<-SCRIPT
   curl -s https://deb.frrouting.org/frr/keys.gpg | sudo tee /usr/share/keyrings/frrouting.gpg > /dev/null
   FRRVER="frr-stable"
   echo deb '[signed-by=/usr/share/keyrings/frrouting.gpg]' https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER | sudo tee -a /etc/apt/sources.list.d/frr.list
-  sudo apt update && sudo apt install -y frr frr-pythontools
+  sudo apt-get update && sudo apt-get install -y frr frr-pythontools
 
   # Delete the default route
   sudo ip route del 0.0.0.0/0 via 10.0.2.2
+
+  # Enable IPv4/IPv6 Forwarding
+  sudo sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/g' /etc/sysctl.conf
+  sudo sed -i 's/#net.ipv6.conf.all.forwarding=1/net.ipv6.conf.all.forwarding=1/g' /etc/sysctl.conf
+  sudo sysctl -p
+
 SCRIPT
 
 frr_config = <<-SCRIPT
-  sudo sed -i 's/bgpd=no/bgpd=yes/g' /etc/frr/daemons
-  sudo sed -i 's/ospfd=no/ospfd=yes/g' /etc/frr/daemons
+  # sudo sed -i 's/bgpd=no/bgpd=yes/g' /etc/frr/daemons
+  # sudo sed -i 's/ospfd=no/ospfd=yes/g' /etc/frr/daemons
   sudo sed -i 's/ripd=no/ripd=yes/g' /etc/frr/daemons
-  sudo sed -i 's/isisd=no/isisd=yes/g' /etc/frr/daemons
-  sudo sed -i 's/eigrpd=no/eigrpd=yes/g' /etc/frr/daemons
-  sudo sed -i 's/vrrpd=no/vrrpd=yes/g' /etc/frr/daemons
+  # sudo sed -i 's/isisd=no/isisd=yes/g' /etc/frr/daemons
+  # sudo sed -i 's/eigrpd=no/eigrpd=yes/g' /etc/frr/daemons
+  # sudo sed -i 's/vrrpd=no/vrrpd=yes/g' /etc/frr/daemons
 
   cat << 'EOF' | sudo tee /etc/frr/frr.conf
 frr version 10.1.1
@@ -41,7 +48,6 @@ router rip
 !
 EOF
   sudo systemctl restart frr
-  sudo sysctl net.ipv4.ip_forward=1
 SCRIPT
 
 Vagrant.configure("2") do |config|
@@ -56,6 +62,6 @@ Vagrant.configure("2") do |config|
     node.vm.network "private_network", ip: "192.168.56.254", nic_type: "virtio"
     node.vm.network "private_network", ip: "192.168.57.254", nic_type: "virtio"
     node.vm.provision "shell", inline: frr_script
-    node.vm.provision "shell", inline: frr_config
+    # node.vm.provision "shell", inline: frr_config
   end
 end


### PR DESCRIPTION
# FRRouting

## 미러 변경 
   - 기본 저장소를 `Kakao mirror`로 변경

## SSH 패스워드 인증 활성화
   - PasswordAuthenticatio
   - KbdInteractiveAuthentication 

## FRR 패키지 설치
   - frr
   - frr-pythontools

## 기본 라우터 삭제
   - 기본 경로 삭제 (`0.0.0.0/0 via 10.0.2.2`)

## FRR 데몬 활성화 (`/etc/frr/daemons`)
- BGP (bgpd)
- OSPF (ospfd)
- RIP (ripd)
- IS-IS (isisd)
- EIGRP (eigrpd)
- VRRP (vrrpd)

## RIP 프로토콜 구성 (`/etc/frr/frr.conf`)
   - RIP 네트워크: `192.168.56.0/24`, `192.168.57.0/24`.

## IP 포워딩 활성화
   - `sysctl net.ipv4.ip_forward=1`